### PR TITLE
add close method test

### DIFF
--- a/src/mrb_filemagic.c
+++ b/src/mrb_filemagic.c
@@ -105,6 +105,7 @@ static mrb_value mrb_filemagic_close(mrb_state *mrb, mrb_value self)
   struct magic_set *magic = NULL;
   magic = data->magic;
   magic_close(magic);
+  return mrb_true_value();
 }
 
 void mrb_mruby_filemagic_gem_init(mrb_state *mrb)

--- a/test/mrb_filemagic.rb
+++ b/test/mrb_filemagic.rb
@@ -32,3 +32,8 @@ assert("FileMagic buffer method test for binary file") do
   assert_equal("ELF 64-bit LSB executable", t.buffer(f.read)[0,25])
 end
 
+assert("FileMagic close method") do
+  t = FileMagic.new(FileMagic::MAGIC_NONE)
+  assert_equal(true, t.close)
+end
+


### PR DESCRIPTION
closeメソッドのテストコードを作成。
filemagicのmagic_closeのコードにも、closeが成功したのかを否かを判定する手法がなかったので、簡単な正常系のみのテストを追加している。
